### PR TITLE
Develop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractCosmologicalEmulators"
 uuid = "c83c1981-e5c4-4837-9eb8-c9b1572acfc6"
 authors = ["Marco Bonici <bonici.marco@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,3 +45,7 @@ function get_emulator_description(input_dict::Dict)
     end
     return nothing
 end
+
+function get_emulator_description(emu::AbstractTrainedEmulators)
+    get_emulator_description(emu.Description)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,4 @@
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 SimpleChains = "de6bee2f-e2f4-4ec7-b6ed-219cc6f6e9e5"
-Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,4 +52,5 @@ sc_emu = SimpleChainsEmulator(Architecture = mlpd, Weights = weights,
     @test_logs (:warn, "We do not know which parameters were included in the emulators training space. Use this trained emulator with caution!") AbstractCosmologicalEmulators.get_emulator_description(Dict("pippo" => "franco"))
     @test_logs (:warn, "No emulator description found!") AbstractCosmologicalEmulators._get_emulator_description_dict(Dict("pippo" => "franco"))
     @test isapprox(run_emulator(input, sc_emu), run_emulator(input, lux_emu))
+    @test get_emulator_description(sc_emu) == get_emulator_description(NN_dict["emulator_description"])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using AbstractCosmologicalEmulators
 using JSON
 using SimpleChains
-using Static
 using Test
 
 m = 100
@@ -48,6 +47,7 @@ sc_emu = SimpleChainsEmulator(Architecture = mlpd, Weights = weights,
     NN_dict["layers"]["layer_1"]["activation_function"]= "adremxud"
     @test_throws ErrorException AbstractCosmologicalEmulators._get_nn_simplechains(NN_dict)
     @test_throws ErrorException AbstractCosmologicalEmulators._get_nn_lux(NN_dict)
+    @test isapprox(run_emulator(input, sc_emu), run_emulator(input, lux_emu))
     get_emulator_description(NN_dict["emulator_description"])
     @test_logs (:warn, "We do not know which parameters were included in the emulators training space. Use this trained emulator with caution!") AbstractCosmologicalEmulators.get_emulator_description(Dict("pippo" => "franco"))
     @test_logs (:warn, "No emulator description found!") AbstractCosmologicalEmulators._get_emulator_description_dict(Dict("pippo" => "franco"))


### PR DESCRIPTION
We have fixed a small bug.
Now we can employ the `get_emulator_description`  method directly on the trained emulators.